### PR TITLE
Make onDestroy final & remove unneeded super call

### DIFF
--- a/app/src/main/java/nl/example/kts/CoroutineViewModel.kt
+++ b/app/src/main/java/nl/example/kts/CoroutineViewModel.kt
@@ -14,8 +14,7 @@ abstract class CoroutineViewModel : ViewModel(),
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main + job
 
-    override fun onCleared() {
+    final override fun onCleared() {
         job.cancel()
-        super.onCleared()
     }
 }


### PR DESCRIPTION
This makes it safer to use it as the job is now always cancelled regardless of the subclass implementation.
`coroutineContext` could also be made `final` BTW.